### PR TITLE
Fixed locale where there were duplicate source assumptions

### DIFF
--- a/checker-isa19/ShortestPath/ShortestPath.thy
+++ b/checker-isa19/ShortestPath/ShortestPath.thy
@@ -28,7 +28,6 @@ locale basic_just_sp =
 
 locale shortest_path_pos_cost =
   basic_just_sp +
-  assumes s_in_G: "s \<in> verts G"
   assumes tail_val: "dist s = 0"
   assumes no_path: "\<And>v. v \<in> verts G \<Longrightarrow> dist v = \<infinity> \<longleftrightarrow> num v = \<infinity>"
   assumes pos_cost: "\<And>e. e \<in> arcs G \<Longrightarrow> 0 \<le> c e"
@@ -53,16 +52,15 @@ by unfold_locales (blast)
 
 locale shortest_path_pos_cost_pred =
   basic_just_sp_pred +
-  assumes s_in_G: "s \<in> verts G"
   assumes tail_val: "dist s = 0"
   assumes no_path: "\<And>v. v \<in> verts G \<Longrightarrow> dist v = \<infinity> \<longleftrightarrow> num v = \<infinity>"
   assumes pos_cost: "\<And>e. e \<in> arcs G \<Longrightarrow> 0 \<le> c e"
 
 sublocale shortest_path_pos_cost_pred \<subseteq> shortest_path_pos_cost
-using shortest_path_pos_cost_pred_axioms 
-by unfold_locales 
-   (auto simp: shortest_path_pos_cost_pred_def 
-   shortest_path_pos_cost_pred_axioms_def)
+  using shortest_path_pos_cost_pred_axioms 
+  by unfold_locales
+   (auto simp: shortest_path_pos_cost_pred_def basic_just_sp_pred_def
+   shortest_path_pos_cost_pred_axioms_def basic_sp_def basic_sp_axioms_def)
 
 lemma tail_value_helper:
   assumes "hd p = last p"

--- a/checker-isa19/ShortestPathCVerification.thy
+++ b/checker-isa19/ShortestPathCVerification.thy
@@ -1439,7 +1439,6 @@ definition basic_sp_inv ::
   "IGraph \<Rightarrow> IEInt \<Rightarrow> ICost \<Rightarrow> IVertex \<Rightarrow> IEInt \<Rightarrow> IPEdge \<Rightarrow> bool" where
   "basic_sp_inv G d c s n p \<equiv>
        (basic_just_sp_inv G d c s n p \<and>
-        s < ivertex_cnt G \<and>
         val d s = 0 \<and>
         no_path_inv G d n (ivertex_cnt G)\<and>
         (\<forall>e < ivertex_cnt G. 0 \<le> c e))"
@@ -1493,15 +1492,20 @@ lemma shortest_path_pos_cost_spc':
         apply argo
        apply (unfold is_dist_def)[1]
        apply (subst val_heap, simp+)
-      apply (simp add: basic_just_sp_inv_def)
+        apply (simp add: basic_just_sp_inv_def)
+       apply (subgoal_tac "fst (iD sc) = val_C (heap_EInt_C s (d +\<^sub>p uint sc))")
+        apply argo
+       apply (unfold is_dist_def is_graph_def)[1]
+       apply (subst val_heap, simp+)
+        apply (simp add: basic_just_sp_inv_def)
+       apply (simp add: is_graph_def)
+      apply (simp add: is_graph_def is_dist_def basic_just_sp_inv_def)
      apply (subgoal_tac "fst (iD sc) = val_C (heap_EInt_C s (d +\<^sub>p uint sc))")
       apply argo
-     apply (unfold is_dist_def is_graph_def)[1]
-     apply (subst val_heap, simp+)
-      apply (simp add: basic_just_sp_inv_def)
-     apply (simp add: is_graph_def)
-    apply (simp add: is_graph_def is_dist_def basic_just_sp_inv_def)
-    apply (rule arrlist_nth, (simp add: uint_nat unat_mono)+)
+     apply (unfold is_dist_def)[1] 
+     apply (simp add: basic_just_sp_inv_def)
+    apply (unfold is_dist_def is_graph_def basic_just_sp_inv_def)[1]
+    apply (rule arrlist_nth, (simp add: uint_nat unat_mono)+) 
    apply (rule_tac P1= "P and 
     (\<lambda>s.  is_graph s iG g \<and>
           is_dist s iG iD d \<and>

--- a/checker-isa19/shortest_path_checker.c
+++ b/checker-isa19/shortest_path_checker.c
@@ -87,6 +87,7 @@ int no_path(Graph *g, EInt *dist, EInt *enu) {
 
 int check_basic_just_sp(Graph *g, EInt *dist, unsigned int *c, unsigned int s, EInt *enu, int *pred) {
     if(!is_wellformed(g)) return 0;
+    if(s >= vertex_cnt(g)) return 0;
     if(dist[s].isInf != 0) return 0;
     if(dist[s].val > 0) return 0;
     if(!trian(g, dist, c)) return 0;
@@ -96,7 +97,6 @@ int check_basic_just_sp(Graph *g, EInt *dist, unsigned int *c, unsigned int s, E
 
 int check_sp(Graph *g, EInt *dist, unsigned int *c, unsigned int s, EInt *enu, int *pred) {
     if(!check_basic_just_sp(g, dist, c, s, enu, pred)) return 0;
-    if(s >= vertex_cnt(g)) return 0;
     if(dist[s].val != 0) return 0;
     if(!no_path(g, dist, enu)) return 0;
     // if(!pos_cost(g, c)) return 0;

--- a/checker-isa19/umm_types.txt
+++ b/checker-isa19/umm_types.txt
@@ -3,20 +3,11 @@ Edge_C
 	second_C:Word 32
 
 Graph_C
-	num_vertices_C:Word 32
 	num_edges_C:Word 32
+	num_vertices_C:Word 32
 	arcs_C:Ptr Edge_C
 
-ENInt_C
-	val_C:Signed_Word 32
-	isInf_C:Signed_Word 32
-
-Cycle_C
-	start_C:Word 32
-	length_C:Word 32
-	path_C:Ptr Word 32
-
-Cycle_set_C
-	no_cycles_C:Word 32
-	cyc_obj_C:Ptr Cycle_C
+EInt_C
+	val_C:Word 32
+	isInf_C:Word 32
 


### PR DESCRIPTION
In `ShortestPath.thy`, the local axiom `s_in_G`, which resides in locales `shortest_path_pos_cost` and `shortest_path_pos_cost_pred`, is duplicated, as it already exists within the sublocale `basic_sp` (check lines 14, 31 and 56).
Thus, the local axiom in both locales can be removed.

From the C implementation standpoint, this implies the condition `if(s >= vertex_cnt(g)) return 0;` needs to be checked in `check_basic_just_sp(...)` and not `check_sp(...)`

From the Isabelle/HOL verification standpoint, the preconditions for `check_basic_just_sp'` (and consequently `check_sp'`) no longer need to have the statement `sc < ivertex_cnt iG` (check lines 1317 and 1435 of the "before" file). Ultimately, the preconditions will now only depend on the abstraction functions, which is what we originally wanted! :smile: 